### PR TITLE
remove duplicate setting header and menu settings spelling

### DIFF
--- a/GameEngine/lwjgl3/src/main/java/io/github/some_example_name/lwjgl3/application_classes/scene/HealthSnakeMenuScene.java
+++ b/GameEngine/lwjgl3/src/main/java/io/github/some_example_name/lwjgl3/application_classes/scene/HealthSnakeMenuScene.java
@@ -55,7 +55,7 @@ public class HealthSnakeMenuScene extends Scene {
 	private float spawnInterval = 3f; // Spawn a new snake every 3 seconds
 	private int maxBackgroundSnakes = 8;
 
-	private String[] menuItems = { "Start Game", "How to Play", "Setting", "Exit" };
+	private String[] menuItems = { "Start Game", "How to Play", "Settings", "Exit" };
 
 	private int selectedItem = 0;
 	private float timeElapsed;
@@ -462,9 +462,9 @@ public class HealthSnakeMenuScene extends Scene {
 		settingsTable.center();
 
 		// Title
-		Label settingsTitle = new Label("SETTINGS", skin);
-		settingsTitle.setFontScale(1.5f);
-		settingsTable.add(settingsTitle).colspan(2).padBottom(40).row();
+		// Label settingsTitle = new Label("SETTINGS", skin);
+		// settingsTitle.setFontScale(1.5f);
+		// settingsTable.add(settingsTitle).colspan(2).padBottom(40).row();
 
 		// Audio settings
 		settingsTable.add(musicLabel).padBottom(10).row();

--- a/GameEngine/lwjgl3/src/main/java/io/github/some_example_name/lwjgl3/application_classes/scene/SnakePauseScene.java
+++ b/GameEngine/lwjgl3/src/main/java/io/github/some_example_name/lwjgl3/application_classes/scene/SnakePauseScene.java
@@ -27,7 +27,7 @@ public class SnakePauseScene extends Scene {
     private String[] menuItems = {
         "Resume Game",
         "Restart Game",
-        "Setting",
+        "Settings",
         "Return to Main Menu",
         "Exit Game"
     };


### PR DESCRIPTION
## Summary by Sourcery

Fix spelling and remove duplicate settings header in menu scenes

Enhancements:
- Corrected the spelling of 'Settings' consistently across menu scenes

Chores:
- Removed redundant settings title label in HealthSnakeMenuScene